### PR TITLE
Add left margin to SPE navbar div

### DIFF
--- a/src/_includes/partials/navbar.html
+++ b/src/_includes/partials/navbar.html
@@ -1,7 +1,7 @@
 <div class="w-full">
     <nav class="flex items-center justify-center lg:justify-between flex-wrap p-6 lg:px-0 container mx-auto" x-data="{ isOpen: false }" @keydown.escape="isOpen = false"  @click.away="isOpen = false">
         <!--Logo etc-->
-        <div class="flex items-center">
+        <div class="flex items-center sm:ml-3 lg:ml-6">
             <a href="/" class="text-indigo-500 font-bold text-lg">
                 SPE</a>
         </div>


### PR DESCRIPTION
This PR gives the SPE link in the navbar some breathing room on the left side.